### PR TITLE
fix: updatewrite endpoint to use HTTP protocol

### DIFF
--- a/lib/appwrite.ts
+++ b/lib/appwrite.ts
@@ -7,7 +7,7 @@ export const ENABLE_CLOUD_FEATURES = true; // Set to true to enable cloud featur
 let hasShownNetworkError = false;
 
 // Appwrite configuration
-const appwriteEndpoint = "https://test-b74502-150-230-144-172.traefik.me/v1";
+const appwriteEndpoint = "http://test-b74502-150-230-144-172.traefik.me/v1";
 const appwriteProjectId = "67d6ea990025fa097964"; // Replace with your actual project ID
 
 // Database configuration


### PR DESCRIPTION
Change the Appwrite endpoint from HTTPS to HTTP to resolve  network connectivity issues during development. This ensures  that the application can successfully communicate with the  Appwrite server without SSL-related errors.