### PR TITLE
fix: update Appwrite endpoint to secure URL

### DIFF
--- a/lib/appwrite.ts
+++ b/lib/appwrite.ts
@@ -7,7 +7,7 @@ export const ENABLE_CLOUD_FEATURES = true; // Set to true to enable cloud featur
 let hasShownNetworkError = false;
 
 // Appwrite configuration
-const appwriteEndpoint = "http://test-b74502-150-230-144-172.traefik.me/v1";
+const appwriteEndpoint = "https://appwrite.nief.tech/v1";
 const appwriteProjectId = "67d6ea990025fa097964"; // Replace with your actual project ID
 
 // Database configuration


### PR DESCRIPTION
Change the Appwrite endpoint from an insecure HTTP URL to a secure  HTTPS URL. This enhances security by ensuring that data is transmitted  over an encrypted connection.